### PR TITLE
Fixed typo in the doc && less tautology

### DIFF
--- a/doc/view.qbk
+++ b/doc/view.qbk
@@ -328,9 +328,7 @@ defined in __forward_sequence__.
 The unary version of `transform_view` presents a view of its underlying
 sequence given a unary function object or function pointer. The binary
 version of `transform_view` presents a view of 2 underlying sequences,
-given a binary function object or function pointer. The `transform_view`
-inherits the traversal characteristics (see __traversal_concept__)  of
-its underlying sequence or sequences.
+given a binary function object or function pointer.
 
 [heading Header]
 
@@ -364,7 +362,7 @@ its underlying sequence or sequences.
 
 * __forward_sequence__, __bidirectional_sequence__ or
 __random_access_sequence__ depending on the traversal characteristics (see
-__traversal_concept__) of its underlying sequence.
+__traversal_concept__) of its underlying sequence or sequences.
 
 [variablelist Notation
     [[`TV`]             [A `transform_view` type]]
@@ -381,9 +379,7 @@ __traversal_concept__) of its underlying sequence.
 [heading Expression Semantics]
 
 Semantics of an expression is defined only where it differs from, or is not
-defined in __forward_sequence__, __bidirectional_sequence__ or
-__random_access_sequence__ depending on the traversal characteristics (see
-__traversal_concept__) of its underlying sequence or sequences.
+defined in the implemented models.
 
 [table
     [[Expression]           [Semantics]]


### PR DESCRIPTION
Edited docs for _transform_view_:
1. Fixed typo in "Model of" section.
2. Rephrased the main description of _transform_view_ and "Expression Semantics" section.